### PR TITLE
Handle terminal transitions in replay buffer

### DIFF
--- a/main.py
+++ b/main.py
@@ -167,7 +167,8 @@ def run_training(config, output_dir):
                 state,
                 action,
                 next_state_tensor, # Use the pre-made tensor
-                torch.tensor([reward], device=device, dtype=torch.float32)
+                torch.tensor([reward], device=device, dtype=torch.float32),
+                torch.tensor([float(done)], device=device, dtype=torch.float32)
             )
             state = next_state_tensor # And reuse it here
 

--- a/neural_symbolic_sssp/sssp_dqn.py
+++ b/neural_symbolic_sssp/sssp_dqn.py
@@ -53,12 +53,14 @@ class NeuroSymbolicSSSP_DQN:
         state_batch = torch.cat(batch.state)
         action_batch = torch.cat(batch.action)
         reward_batch = torch.cat(batch.reward)
+        done_batch = torch.cat(batch.done)
         next_state_batch = torch.cat(batch.next_state)
         q_values = self.policy_net(state_batch).gather(1, action_batch)
         best_next_actions = self.policy_net(next_state_batch).argmax(1).unsqueeze(1)
         q_values_next_target = self.target_net(next_state_batch)
         next_q_values = q_values_next_target.gather(1, best_next_actions).squeeze(1).detach()
-        expected_q_values = (next_q_values * self.config['gamma']) + reward_batch
+        non_terminal_mask = 1.0 - done_batch
+        expected_q_values = (next_q_values * self.config['gamma'] * non_terminal_mask) + reward_batch
         loss = F.mse_loss(q_values, expected_q_values.unsqueeze(1))
         self.policy_optimizer.zero_grad()
         loss.backward()

--- a/neural_symbolic_sssp/utils.py
+++ b/neural_symbolic_sssp/utils.py
@@ -3,7 +3,7 @@
 import random
 from collections import deque, namedtuple
 
-Transition = namedtuple('Transition', ('state', 'action', 'next_state', 'reward'))
+Transition = namedtuple('Transition', ('state', 'action', 'next_state', 'reward', 'done'))
 
 class ReplayBuffer:
     """A simple replay buffer."""


### PR DESCRIPTION
## Summary
- add terminal flag support to replay buffer transitions
- propagate the done mask through DQN updates to stop bootstrapping past terminal states
- push the done signal from the environment into replay entries

## Testing
- python -m compileall neural_symbolic_sssp main.py

------
https://chatgpt.com/codex/tasks/task_e_68d5e273a2d48333a4756362c1246d20