### PR TITLE
Include done flag in replay buffer pushes

### DIFF
--- a/single_run.py
+++ b/single_run.py
@@ -123,8 +123,9 @@ def run_training(config, output_dir):
 
             next_state_tensor = torch.tensor(np.array([next_state_np]), device=device, dtype=torch.float32)
             reward_tensor = torch.tensor([reward], device=device, dtype=torch.float32)
+            done_tensor = torch.tensor([float(done)], device=device, dtype=torch.float32)
 
-            agent.memory.push(state, action, next_state_tensor, reward_tensor)
+            agent.memory.push(state, action, next_state_tensor, reward_tensor, done_tensor)
             state = next_state_tensor
 
             # --- UPDATED TRAINING STEP ---


### PR DESCRIPTION
## Summary
- convert the `done` flag returned from the environment step into a float tensor
- push the `done` tensor to replay memory alongside the existing transition values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ed0ff88c8333a2f3063c9a475843